### PR TITLE
TT-1419 Add default value to NameIdBuilder

### DIFF
--- a/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdBuilder.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdBuilder.java
@@ -8,7 +8,7 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 public class NameIdBuilder {
 
     private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-    private String value;
+    private String value = "default-pid";
     private Optional<String> format = Optional.fromNullable(NameIDType.PERSISTENT);
     private Optional<String> nameQualifier = Optional.absent();
     private Optional<String> spNameQualifier = Optional.absent();


### PR DESCRIPTION
i.e. Ensure generic aNameId(), and hence aSubject(), contains a pid

Authors: @rachaelbooth