### PR TITLE
TEST: Build using OpenJDK

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -5,7 +5,7 @@ pipeline {
         stage('Build') {
             agent {
                 docker {
-                    image 'govukverify/java8:latest'
+                    image 'govukverify/java8:PR-5.6'
                 }
             }
             steps {
@@ -28,7 +28,7 @@ pipeline {
         stage('Publish') {
             agent {
                 docker {
-                    image 'govukverify/java8:latest'
+                    image 'govukverify/java8:PR-5.6'
                 }
             }
             environment {


### PR DESCRIPTION
**Do not merge - this branch is for testing OpenJDK only**

To avoid the licencing issues around distributing Oracle's code, we're
moving to building our projects using OpenJDK. In order to test that
this works for this project, we are first changing its Dockerfile to
pull FROM our initial openjdk-based version of our java8 Docker image.

Authors: @roryirvine